### PR TITLE
set django_allowed_host env for docker on linux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     environment:
       DJANGO_SECRET_KEY: reallysupersecret
       DJANGO_MANAGEPY_MIGRATE: "on"
+      DJANGO_ALLOWED_HOSTS: 172.17.0.1,localhost,127.0.0.1
     entrypoint: /app/docker-entrypoint.sh
     command: python manage.py runserver 0.0.0.0:8000
 


### PR DESCRIPTION
@antidipyramid ran into a problem running this code on linux.

> This implementation was built on Linux. After some research, it became clear that there
> are some operating system differences in how Docker applications can access localhost
> (as I needed to do in order to implement the unit tests).
> 
> As a result, I had to modify Django's settings to allow the host 172.17.0.1, which Docker
> uses in Linux. I don't believe this would affect anything in Mac or Windows, but please
> let me know if you have any problems running the application. Thank you!

This PR fixes this by setting an environmental variable that will be used by [this line in the settings.py file](https://github.com/datamade/code-challenge/blob/master/parserator_web/settings.py#L27)