### PR TITLE
feature/challenge-attempt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Other directories
+/notes
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# Other directories
+# Other directories and files
 /notes
+.idea
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -12,7 +12,12 @@ function getAddress() {
 }
 
 function submitAddress() {
+   var address = getAddress();
    var url = "api/parse?address=" + getAddress();
+   if (address === "") {
+      writeError("Please enter an address.");
+      return;
+   }
    try {
       fetch(url)
          .then((res) => handleResponse(res));

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -19,8 +19,7 @@ function submitAddress() {
       return;
    }
    try {
-      fetch(url)
-         .then((res) => handleResponse(res));
+      fetch(url).then(res => handleResponse(res));
    } catch (error) {
       writeError("Something went wrong, please try again.");
    }
@@ -28,13 +27,9 @@ function submitAddress() {
 
 function handleResponse(response) {
    if (response.ok) {
-      response.json().then(jsonData => {
-         writeResults(jsonData.address_type, jsonData.address_components);
-      });
+      response.json().then(jsonData => writeResults(jsonData.address_type, jsonData.address_components));
    } else {
-      response.json().then(jsonData => {
-         writeError(jsonData.detail);
-      });
+      response.json().then(jsonData => writeError(jsonData.detail));
    }
 }
 

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -2,21 +2,19 @@
    in the #address-results div. */
 
 $('.form').on('submit', function (event) {
-   // Prevent default form submission behavior
    event.preventDefault();
-
-   var address = getAddress();
-   submitAddress(address);
+   submitAddress();
 });
 
 function getAddress() {
-   return $("#address").val().trim();
+   var address = $("#address").val();
+   return address.trim().replaceAll(" ", "+");
 }
 
-async function submitAddress(address) {
-   var preparedAddress = address.replaceAll(" ", "+");
+async function submitAddress() {
+   var url = "api/parse?address=" + getAddress();
    try {
-      fetch("api/parse?address=" + preparedAddress)
+      fetch(url)
          .then((res) => handleResponse(res));
    } catch (error) {
       writeError("Something went wrong, please try again.");
@@ -36,10 +34,12 @@ async function handleResponse(response) {
 }
 
 function writeResults(addressType, addressComponents) {
-   // Write Address Type text
-   $("#parse-type").text(addressType);
+   writeTextById("parse-type", addressType);
+   writeAddressComponents(addressComponents);
+   showResults();
+}
 
-   // Write Address Components table
+function writeAddressComponents(addressComponents) {
    $("#address-parts").empty();
    for (var component in addressComponents) {
       if (Object.prototype.hasOwnProperty.call(addressComponents, component)) {
@@ -47,27 +47,33 @@ function writeResults(addressType, addressComponents) {
          $("#address-parts").append(row);
       }
    }
-
-   showResults();
 }
 
 function writeError(message) {
-   // Write Error Message text
-   $("#error-message").text(message);
-
+   writeTextById("error-message", message);
    showError();
 }
 
-
+function writeTextById(id, text) {
+   $(`#${id}`).text(text);
+}
 
 function showResults() {
-   showOrHideById("error", false)
-   showOrHideById("address-results", true)
+   hide("error")
+   show("address-results")
 }
 
 function showError() {
-   showOrHideById("address-results", false)
-   showOrHideById("error", true)
+   hide("address-results")
+   show("error")
+}
+
+function show(id) {
+   showOrHideById(id, true)
+}
+
+function hide(id) {
+   showOrHideById(id, false)
 }
 
 function showOrHideById(id, show) {

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -1,81 +1,85 @@
 /* Connects the form to the API and render results
    in the #address-results div. */
 
+'use strict'
+
 $('.form').on('submit', function (event) {
-   event.preventDefault();
-   submitAddress();
-});
+  event.preventDefault()
+  submitAddress()
+})
 
-function getAddress() {
-   var address = $("#address").val();
-   return address.trim().replaceAll(" ", "+");
+function submitAddress () {
+  var address = getAddress()
+  var url = "api/parse?address=" + getAddress()
+  if (address === "") {
+    writeError("Please enter an address.")
+    return
+  }
+  try {
+    $.get(url, function (data) {
+      writeResults(data.address_type, data.address_components)
+    }).fail(function (data) {
+      writeError(data.responseJSON.detail)
+    })
+  } catch (error) {
+    writeError("Something went wrong, please try again.")
+  }
 }
 
-function submitAddress() {
-   var address = getAddress();
-   var url = "api/parse?address=" + getAddress();
-   if (address === "") {
-      writeError("Please enter an address.");
-      return;
-   }
-   try {
-      $.get(url, function (data) {
-         writeResults(data.address_type, data.address_components);
-      }).fail(function (data) {
-         writeError(data.responseJSON.detail);
-      })
-   } catch (error) {
-      writeError("Something went wrong, please try again.");
-   }
+function getAddress () {
+  var address = $("#address").val()
+  return address.trim().replaceAll(" ", "+")
 }
 
-function writeResults(addressType, addressComponents) {
-   writeTextById("parse-type", addressType);
-   writeAddressComponents(addressComponents);
-   showSuccess();
+function writeResults (addressType, addressComponents) {
+  writeTextById("parse-type", addressType)
+  writeAddressComponents(addressComponents)
+  showSuccess()
 }
 
-function writeAddressComponents(addressComponents) {
-   $("#address-parts").empty();
-   for (var component in addressComponents) {
-      if (Object.prototype.hasOwnProperty.call(addressComponents, component)) {
-         var row = '<tr><td>' + addressComponents[component] + '</td><td>' + component + '</td></tr>';
-         $("#address-parts").append(row);
-      }
-   }
+function writeAddressComponents (addressComponents) {
+  $("#address-parts").empty()
+  for (var component in addressComponents) {
+    if (Object.prototype.hasOwnProperty.call(addressComponents, component)) {
+      var addressPart = addressComponents[component]
+      var tag = component
+      var row = '<tr><td>' + addressPart + '</td><td>' + tag + '</td></tr>'
+      $("#address-parts").append(row)
+    }
+  }
 }
 
-function writeError(message) {
-   writeTextById("error-message", message);
-   showError();
+function writeError (message) {
+  writeTextById("error-message", message)
+  showError()
 }
 
-function showSuccess() {
-   hide("error");
-   show("success");
-   show("address-results");
+function showSuccess () {
+  hide("error")
+  show("success")
+  show("address-results")
 }
 
-function showError() {
-   hide("success");
-   show("error");
-   show("address-results");
+function showError () {
+  hide("success")
+  show("error")
+  show("address-results")
 }
 
-function show(id) {
-   showOrHideById(id, true)
+function show (id) {
+  showOrHideById(id, true)
 }
 
-function hide(id) {
-   showOrHideById(id, false)
+function hide (id) {
+  showOrHideById(id, false)
 }
 
-function showOrHideById(id, show) {
-   var setting = show ? '' : 'none';
-   $("#" + id).css("display", setting);
+function showOrHideById (id, show) {
+  var setting = show ? '' : 'none'
+  $("#" + id).css("display", setting)
 }
 
 
-function writeTextById(id, text) {
-   $("#" + id).text(text);
+function writeTextById (id, text) {
+  $("#" + id).text(text)
 }

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -11,7 +11,7 @@ function getAddress() {
    return address.trim().replaceAll(" ", "+");
 }
 
-async function submitAddress() {
+function submitAddress() {
    var url = "api/parse?address=" + getAddress();
    try {
       fetch(url)
@@ -21,7 +21,7 @@ async function submitAddress() {
    }
 }
 
-async function handleResponse(response) {
+function handleResponse(response) {
    if (response.ok) {
       response.json().then(jsonData => {
          writeResults(jsonData.address_type, jsonData.address_components);
@@ -54,10 +54,6 @@ function writeError(message) {
    showError();
 }
 
-function writeTextById(id, text) {
-   $(`#${id}`).text(text);
-}
-
 function showResults() {
    hide("error")
    show("address-results")
@@ -79,4 +75,9 @@ function hide(id) {
 function showOrHideById(id, show) {
    var setting = show ? '' : 'none';
    $(`#${id}`).css("display", setting);
+}
+
+
+function writeTextById(id, text) {
+   $(`#${id}`).text(text);
 }

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -10,33 +10,34 @@ $('.form').on('submit', function (event) {
 });
 
 function getAddress() {
-   var address = $("#address").val().trim();
-   console.log(`Submitted form with: ${address}`);
-   return address;
+   return $("#address").val().trim();
 }
 
 async function submitAddress(address) {
+   var preparedAddress = address.replaceAll(" ", "+");
    try {
-      // TODO submit results to API properly
-      var preparedAddress = address.replaceAll(" ", "+");
-      var response = await fetch("api/parse?address=" + preparedAddress);
-      if (response.ok) {
-         var parseResponse = response.json();
-         writeResults(parseResponse);
-      } else {
-         showError();
-      }
+      fetch("api/parse?address=" + preparedAddress)
+         .then((res) => handleResponse(res));
    } catch (error) {
       showError();
    }
 }
 
-function writeResults(parseResponse) {
+async function handleResponse(response) {
+   if (response.ok) {
+      var jsonData = await response.json();
+      writeResults(jsonData.address_type, jsonData.address_components);
+   } else {
+      showError();
+   }
+}
+
+function writeResults(addressType, addressComponents) {
    // Write Address Type text
-   $("#parse-type").text(parseResponse.address_type);
+   $("#parse-type").text(addressType);
 
    // TODO Write Address Components table
-   console.log(parseResponse.address_components)
+   console.log(addressComponents);
 
    showResults();
 }

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -19,17 +19,13 @@ function submitAddress() {
       return;
    }
    try {
-      fetch(url).then(res => handleResponse(res));
+      $.get(url, function (data) {
+         writeResults(data.address_type, data.address_components);
+      }).fail(function (data) {
+         writeError(data.responseJSON.detail);
+      })
    } catch (error) {
       writeError("Something went wrong, please try again.");
-   }
-}
-
-function handleResponse(response) {
-   if (response.ok) {
-      response.json().then(jsonData => writeResults(jsonData.address_type, jsonData.address_components));
-   } else {
-      response.json().then(jsonData => writeError(jsonData.detail));
    }
 }
 
@@ -43,7 +39,7 @@ function writeAddressComponents(addressComponents) {
    $("#address-parts").empty();
    for (var component in addressComponents) {
       if (Object.prototype.hasOwnProperty.call(addressComponents, component)) {
-         var row = `<tr><td>${addressComponents[component]}</td><td>${component}</td></tr>`
+         var row = '<tr><td>' + addressComponents[component] + '</td><td>' + component + '</td></tr>';
          $("#address-parts").append(row);
       }
    }
@@ -76,10 +72,10 @@ function hide(id) {
 
 function showOrHideById(id, show) {
    var setting = show ? '' : 'none';
-   $(`#${id}`).css("display", setting);
+   $("#" + id).css("display", setting);
 }
 
 
 function writeTextById(id, text) {
-   $(`#${id}`).text(text);
+   $("#" + id).text(text);
 }

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -19,16 +19,19 @@ async function submitAddress(address) {
       fetch("api/parse?address=" + preparedAddress)
          .then((res) => handleResponse(res));
    } catch (error) {
-      showError();
+      writeError("Something went wrong, please try again.");
    }
 }
 
 async function handleResponse(response) {
    if (response.ok) {
-      var jsonData = await response.json();
-      writeResults(jsonData.address_type, jsonData.address_components);
+      response.json().then(jsonData => {
+         writeResults(jsonData.address_type, jsonData.address_components);
+      });
    } else {
-      showError();
+      response.json().then(jsonData => {
+         writeError(jsonData.detail);
+      });
    }
 }
 
@@ -47,6 +50,15 @@ function writeResults(addressType, addressComponents) {
 
    showResults();
 }
+
+function writeError(message) {
+   // Write Error Message text
+   $("#error-message").text(message);
+
+   showError();
+}
+
+
 
 function showResults() {
    showOrHideById("error", false)

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -1,8 +1,41 @@
-/* TODO: Flesh this out to connect the form to the API and render results
+/* Connects the form to the API and render results
    in the #address-results div. */
 
-   $('.form').on('submit', function () {
-      var address = document.getElementById('address').value;
-      alert(`Submitted form with: ${address}`);
-  });
-  
+$('.form').on('submit', function (event) {
+   // Prevent default form submission behavior
+   event.preventDefault();
+
+   var address = getAddress();
+   submitAddress(address);
+
+});
+
+function getAddress() {
+   var address = $("#address").val().trim();
+   console.log(`Submitted form with: ${address}`);
+   return address;
+}
+
+async function submitAddress(address) {
+   try {
+      // TODO submit results to API properly
+      var res = await fetch("api/parse?address=" + address);
+      var data = await res.json();
+      console.log(res);
+      renderAddress("Address Type", []);
+   } catch (error) {
+      console.log(error);
+   }
+}
+
+function renderAddress(addressType, addressComponents) {
+   // TODO render results in the #address-results div
+
+   // Write Address Type text
+   $("#parse-type").text(addressType);
+
+   // TODO Write Address Components table
+
+   // Set Address Results div to show
+   $("#address-results").css("display", '');
+}

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -36,7 +36,7 @@ function handleResponse(response) {
 function writeResults(addressType, addressComponents) {
    writeTextById("parse-type", addressType);
    writeAddressComponents(addressComponents);
-   showResults();
+   showSuccess();
 }
 
 function writeAddressComponents(addressComponents) {
@@ -54,14 +54,16 @@ function writeError(message) {
    showError();
 }
 
-function showResults() {
-   hide("error")
-   show("address-results")
+function showSuccess() {
+   hide("error");
+   show("success");
+   show("address-results");
 }
 
 function showError() {
-   hide("address-results")
-   show("error")
+   hide("success");
+   show("error");
+   show("address-results");
 }
 
 function show(id) {

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -7,7 +7,6 @@ $('.form').on('submit', function (event) {
 
    var address = getAddress();
    submitAddress(address);
-
 });
 
 function getAddress() {
@@ -19,24 +18,40 @@ function getAddress() {
 async function submitAddress(address) {
    try {
       // TODO submit results to API properly
-      var res = await fetch("api/parse?address=" + address);
-      var parseResponse = await res.json();
-      renderAddress(parseResponse);
+      var preparedAddress = address.replaceAll(" ", "+");
+      var response = await fetch("api/parse?address=" + preparedAddress);
+      if (response.ok) {
+         var parseResponse = response.json();
+         writeResults(parseResponse);
+      } else {
+         showError();
+      }
    } catch (error) {
-      console.log(error);
+      showError();
    }
 }
 
-function renderAddress(parseResponse) {
-   console.log(parseResponse.input_string);
-   // TODO render results in the #address-results div
-
+function writeResults(parseResponse) {
    // Write Address Type text
    $("#parse-type").text(parseResponse.address_type);
 
    // TODO Write Address Components table
    console.log(parseResponse.address_components)
 
-   // Set Address Results div to show
-   $("#address-results").css("display", '');
+   showResults();
+}
+
+function showResults() {
+   showOrHideById("error", false)
+   showOrHideById("address-results", true)
+}
+
+function showError() {
+   showOrHideById("address-results", false)
+   showOrHideById("error", true)
+}
+
+function showOrHideById(id, show) {
+   var setting = show ? '' : 'none';
+   $(`#${id}`).css("display", setting);
 }

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -20,21 +20,22 @@ async function submitAddress(address) {
    try {
       // TODO submit results to API properly
       var res = await fetch("api/parse?address=" + address);
-      var data = await res.json();
-      console.log(res);
-      renderAddress("Address Type", []);
+      var parseResponse = await res.json();
+      renderAddress(parseResponse);
    } catch (error) {
       console.log(error);
    }
 }
 
-function renderAddress(addressType, addressComponents) {
+function renderAddress(parseResponse) {
+   console.log(parseResponse.input_string);
    // TODO render results in the #address-results div
 
    // Write Address Type text
-   $("#parse-type").text(addressType);
+   $("#parse-type").text(parseResponse.address_type);
 
    // TODO Write Address Components table
+   console.log(parseResponse.address_components)
 
    // Set Address Results div to show
    $("#address-results").css("display", '');

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -1,2 +1,8 @@
 /* TODO: Flesh this out to connect the form to the API and render results
    in the #address-results div. */
+
+   $('.form').on('submit', function () {
+      var address = document.getElementById('address').value;
+      alert(`Submitted form with: ${address}`);
+  });
+  

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -36,8 +36,14 @@ function writeResults(addressType, addressComponents) {
    // Write Address Type text
    $("#parse-type").text(addressType);
 
-   // TODO Write Address Components table
-   console.log(addressComponents);
+   // Write Address Components table
+   $("#address-parts").empty();
+   for (var component in addressComponents) {
+      if (Object.prototype.hasOwnProperty.call(addressComponents, component)) {
+         var row = `<tr><td>${addressComponents[component]}</td><td>${component}</td></tr>`
+         $("#address-parts").append(row);
+      }
+   }
 
    showResults();
 }

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -27,8 +27,8 @@ function submitAddress () {
 }
 
 function getAddress () {
-  var address = $("#address").val()
-  return address.trim().replaceAll(" ", "+")
+  var address = $("#address").val().trim()
+  return encodeURIComponent(address)
 }
 
 function writeResults (addressType, addressComponents) {
@@ -78,7 +78,6 @@ function showOrHideById (id, show) {
   var setting = show ? '' : 'none'
   $("#" + id).css("display", setting)
 }
-
 
 function writeTextById (id, text) {
   $("#" + id).text(text)

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -10,11 +10,16 @@ $('.form').on('submit', function (event) {
 
 function submitAddress () {
   var address = getAddress()
-  var url = "api/parse?address=" + getAddress()
   if (address === "") {
     writeError("Please enter an address.")
     return
+  } else {
+    makeParseAddressRequest(address)
   }
+}
+
+function makeParseAddressRequest (address) {
+  var url = "api/parse?address=" + encodeURIComponent(address)
   try {
     $.get(url, function (data) {
       writeResults(data.address_type, data.address_components)
@@ -27,8 +32,8 @@ function submitAddress () {
 }
 
 function getAddress () {
-  var address = $("#address").val().trim()
-  return encodeURIComponent(address)
+  var address = $("#address").val()
+  return address.trim()
 }
 
 function writeResults (addressType, addressComponents) {

--- a/parserator_web/templates/parserator_web/index.html
+++ b/parserator_web/templates/parserator_web/index.html
@@ -17,7 +17,7 @@
           <button id="submit" type="submit" class="btn btn-success mt-3">Parse!</button>
         </form>
       </div>
-      <!-- TODO: Display parsed address components here. -->
+      <!-- Displays parsed address components here. -->
       <div id="address-results" style="display:none">
         <h4>Parsing results</h4>
         <p>Address type: <strong><span id="parse-type"></span></strong></p>

--- a/parserator_web/templates/parserator_web/index.html
+++ b/parserator_web/templates/parserator_web/index.html
@@ -34,7 +34,7 @@
               <th>Tag</th>
             </tr>
           </thead>
-          <tbody>
+          <tbody id="address-parts">
           </tbody>
         </table>
       </div>

--- a/parserator_web/templates/parserator_web/index.html
+++ b/parserator_web/templates/parserator_web/index.html
@@ -21,7 +21,7 @@
       <!-- Displays Error here. -->
       <div id="error" style="background-color: red; color: white; padding: 5px;" style="display:none">
         <h4>Error</h4>
-        <p>Please reformat your input and try again.</p>
+        <p id="error-message">Please reformat your input and try again.</p>
       </div>
       <!-- Displays parsed address components here. -->
       <div id="address-results" style="display:none">

--- a/parserator_web/templates/parserator_web/index.html
+++ b/parserator_web/templates/parserator_web/index.html
@@ -17,6 +17,12 @@
           <button id="submit" type="submit" class="btn btn-success mt-3">Parse!</button>
         </form>
       </div>
+      <br>
+      <!-- Displays Error here. -->
+      <div id="error" style="display:none">
+        <h4>Error</h4>
+        <p>Please reformat your input and try again.</p>
+      </div>
       <!-- Displays parsed address components here. -->
       <div id="address-results" style="display:none">
         <h4>Parsing results</h4>

--- a/parserator_web/templates/parserator_web/index.html
+++ b/parserator_web/templates/parserator_web/index.html
@@ -19,12 +19,12 @@
       </div>
       <br>
       <div id="address-results" style="display:none">
-        <!-- Displays Error here. -->
+        <!-- Display Errors here. -->
         <div id="error" style="background-color: red; color: white; padding: 5px; display:none;">
           <h4>Error</h4>
           <p id="error-message"></p>
         </div>
-        <!-- Displays Parsed Components here. -->
+        <!-- Display Parsed Components here. -->
         <div id="success" style="display:none">
           <h4>Parsing results</h4>
           <p>Address type: <strong><span id="parse-type"></span></strong></p>

--- a/parserator_web/templates/parserator_web/index.html
+++ b/parserator_web/templates/parserator_web/index.html
@@ -19,9 +19,9 @@
       </div>
       <br>
       <!-- Displays Error here. -->
-      <div id="error" style="background-color: red; color: white; padding: 5px;" style="display:none">
+      <div id="error" style="background-color: red; color: white; padding: 5px; display:none;">
         <h4>Error</h4>
-        <p id="error-message">Please reformat your input and try again.</p>
+        <p id="error-message"></p>
       </div>
       <!-- Displays parsed address components here. -->
       <div id="address-results" style="display:none">

--- a/parserator_web/templates/parserator_web/index.html
+++ b/parserator_web/templates/parserator_web/index.html
@@ -19,7 +19,7 @@
       </div>
       <br>
       <!-- Displays Error here. -->
-      <div id="error" style="display:none">
+      <div id="error" style="background-color: red; color: white; padding: 5px;" style="display:none">
         <h4>Error</h4>
         <p>Please reformat your input and try again.</p>
       </div>

--- a/parserator_web/templates/parserator_web/index.html
+++ b/parserator_web/templates/parserator_web/index.html
@@ -18,25 +18,27 @@
         </form>
       </div>
       <br>
-      <!-- Displays Error here. -->
-      <div id="error" style="background-color: red; color: white; padding: 5px; display:none;">
-        <h4>Error</h4>
-        <p id="error-message"></p>
-      </div>
-      <!-- Displays parsed address components here. -->
       <div id="address-results" style="display:none">
-        <h4>Parsing results</h4>
-        <p>Address type: <strong><span id="parse-type"></span></strong></p>
-        <table class="table table-bordered">
-          <thead>
-            <tr>
-              <th>Address part</th>
-              <th>Tag</th>
-            </tr>
-          </thead>
-          <tbody id="address-parts">
-          </tbody>
-        </table>
+        <!-- Displays Error here. -->
+        <div id="error" style="background-color: red; color: white; padding: 5px; display:none;">
+          <h4>Error</h4>
+          <p id="error-message"></p>
+        </div>
+        <!-- Displays Parsed Components here. -->
+        <div id="success" style="display:none">
+          <h4>Parsing results</h4>
+          <p>Address type: <strong><span id="parse-type"></span></strong></p>
+          <table class="table table-bordered">
+            <thead>
+              <tr>
+                <th>Address part</th>
+                <th>Tag</th>
+              </tr>
+            </thead>
+            <tbody id="address-parts">
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   </div>

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -17,6 +17,7 @@ class AddressParse(APIView):
         # Parse an address string using the
         # parse() method and return the parsed components to the frontend.
         address_components, address_type = self.parse(request)
+        # TODO handle invalid input
         return Response({
             'input_string': request,
             'address_components': address_components,

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -14,13 +14,18 @@ class AddressParse(APIView):
     renderer_classes = [JSONRenderer]
 
     def get(self, request):
-        # TODO: Flesh out this method to parse an address string using the
+        # Parse an address string using the
         # parse() method and return the parsed components to the frontend.
-        return Response({})
+        address_components, address_type = self.parse(request)
+        return Response({
+            'input_string': request,
+            'address_components': address_components,
+            'address_type': address_type
+        })
 
     def parse(self, address):
         # Returns the parsed components of a
-        # given address using [usaddress](https://github.com/datamade/usaddress)
+        # given address using usaddress: https://github.com/datamade/usaddress
         parse_result = usaddress.tag(address)
         address_components = parse_result[0]
         address_type = parse_result[1]

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -26,7 +26,6 @@ class AddressParse(APIView):
                 'address_type': address_type
             })
         except Exception as e:
-            # TODO better handle parse error?
             raise ParseError(e)
 
     def parse(self, address):

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -20,7 +20,7 @@ class AddressParse(APIView):
         # Parse an address string using the
         # parse() method and return the parsed components to the frontend.
         try:
-            address_components, address_type = self.parse(request)
+            address_components, address_type = self.parse(input_address)
             return Response({
                 'input_string': input_address,
                 'address_components': address_components,

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -4,6 +4,7 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.renderers import JSONRenderer
 from rest_framework.exceptions import ParseError
+from urllib.parse import unquote
 
 
 class Home(TemplateView):
@@ -14,14 +15,15 @@ class AddressParse(APIView):
     renderer_classes = [JSONRenderer]
 
     def get(self, request):
-        input_address = request.GET.get('address', "")
-        if input_address == "":
+        address_query_param = request.GET.get('address', "")
+        if address_query_param == "":
             raise ParseError("Non-blank address query param must be provided.")
+        input_string = unquote(address_query_param)
 
         try:
-            address_components, address_type = self.parse(input_address)
+            address_components, address_type = self.parse(input_string)
             return Response({
-                'input_string': input_address,
+                'input_string': input_string,
                 'address_components': address_components,
                 'address_type': address_type
             })

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -19,6 +19,9 @@ class AddressParse(APIView):
         return Response({})
 
     def parse(self, address):
-        # TODO: Implement this method to return the parsed components of a
-        # given address using usaddress: https://github.com/datamade/usaddress
+        # Returns the parsed components of a
+        # given address using [usaddress](https://github.com/datamade/usaddress)
+        parse_result = usaddress.tag(address)
+        address_components = parse_result[0]
+        address_type = parse_result[1]
         return address_components, address_type

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -14,12 +14,20 @@ class AddressParse(APIView):
     renderer_classes = [JSONRenderer]
 
     def get(self, request):
+        # request uses: https://www.django-rest-framework.org/api-guide/requests/
+
         # Parse an address string using the
         # parse() method and return the parsed components to the frontend.
-        address_components, address_type = self.parse(request)
+        # address_components, address_type = self.parse(request)
+
+        input_address = request.query_params['address']
+        address_components = []
+        address_type = "Test Type"
+        
         # TODO handle invalid input
+        
         return Response({
-            'input_string': request,
+            'input_string': input_address,
             'address_components': address_components,
             'address_type': address_type
         })

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -15,22 +15,19 @@ class AddressParse(APIView):
 
     def get(self, request):
         # request uses: https://www.django-rest-framework.org/api-guide/requests/
+        input_address = request.query_params['address']
 
         # Parse an address string using the
         # parse() method and return the parsed components to the frontend.
-        # address_components, address_type = self.parse(request)
-
-        input_address = request.query_params['address']
-        address_components = []
-        address_type = "Test Type"
-        
-        # TODO handle invalid input
-        
-        return Response({
-            'input_string': input_address,
-            'address_components': address_components,
-            'address_type': address_type
-        })
+        try:
+            address_components, address_type = self.parse(request)
+            return Response({
+                'input_string': input_address,
+                'address_components': address_components,
+                'address_type': address_type
+            })
+        except:
+            raise ParseError(f'The submitted address "{input_address}" was not able to be parsed.')
 
     def parse(self, address):
         # Returns the parsed components of a

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -14,7 +14,9 @@ class AddressParse(APIView):
     renderer_classes = [JSONRenderer]
 
     def get(self, request):
-        input_address = request.query_params['address']
+        input_address = request.GET.get('address', "")
+        if input_address == "":
+            raise ParseError("Non-blank address query param must be provided.")
 
         try:
             address_components, address_type = self.parse(input_address)
@@ -24,6 +26,7 @@ class AddressParse(APIView):
                 'address_type': address_type
             })
         except Exception as e:
+            # TODO better handle parse error?
             raise ParseError(e)
 
     def parse(self, address):

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -14,11 +14,8 @@ class AddressParse(APIView):
     renderer_classes = [JSONRenderer]
 
     def get(self, request):
-        # request uses: https://www.django-rest-framework.org/api-guide/requests/
         input_address = request.query_params['address']
 
-        # Parse an address string using the
-        # parse() method and return the parsed components to the frontend.
         try:
             address_components, address_type = self.parse(input_address)
             return Response({
@@ -26,8 +23,9 @@ class AddressParse(APIView):
                 'address_components': address_components,
                 'address_type': address_type
             })
-        except:
-            raise ParseError(f'The submitted address "{input_address}" was not able to be parsed.')
+        except Exception as e:
+            message = f"Sorry, we failed to parse the submitted address. Check for errors or try a different format."
+            raise ParseError(message)
 
     def parse(self, address):
         # Returns the parsed components of a

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -24,12 +24,9 @@ class AddressParse(APIView):
                 'address_type': address_type
             })
         except Exception as e:
-            message = f"Sorry, we failed to parse the submitted address. Check for errors or try a different format."
-            raise ParseError(message)
+            raise ParseError(e)
 
     def parse(self, address):
-        # Returns the parsed components of a
-        # given address using usaddress: https://github.com/datamade/usaddress
         parse_result = usaddress.tag(address)
         address_components = parse_result[0]
         address_type = parse_result[1]

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4,12 +4,32 @@ import pytest
 def test_api_parse_succeeds(client):
     # TODO: Finish this test. Send a request to the API and confirm that the
     # data comes back in the appropriate format.
+
+    # Arrange
     address_string = '123 main st chicago il'
-    pytest.fail()
+
+    # Act
+    actual = None
+
+    # Assert
+    expected = Response({
+                'input_string': address_string,
+                'address_components': [],
+                'address_type': ""
+            })
+    assert expected == actual
 
 
 def test_api_parse_raises_error(client):
     # TODO: Finish this test. The address_string below will raise a
     # RepeatedLabelError, so ParseAddress.parse() will not be able to parse it.
+    
+    # Arrange
     address_string = '123 main st chicago il 123 main st'
-    pytest.fail()
+
+    # Act
+    actual = None
+
+    # Assert
+    expected = None
+    assert actual == None

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,11 +1,11 @@
 import ast
+from urllib.parse import quote_plus
 
 
 def test_api_parse_succeeds(client, mocker):
     # Arrange
     address_string = '123 main st chicago il'
-    prepared_string = address_string.replace(" ", "+")
-    url = "/api/parse/?address=" + prepared_string
+    url = "/api/parse/?address=" + quote_plus(address_string)
 
     # Mock a healthy usaddress response.
     # We mock because we don't need to test the usaddress library.
@@ -35,8 +35,7 @@ def test_api_parse_succeeds(client, mocker):
 def test_api_parse_raises_error_if_usaddress_raises_error(client, mocker):
     # Arrange
     address_string = '123 main st chicago il 123 main st'
-    prepared_string = address_string.replace(" ", "+")
-    url = "/api/parse/?address=" + prepared_string
+    url = "/api/parse/?address=" + quote_plus(address_string)
 
     # Mock an Exception within usaddress.
     # We mock because we don't need to test the usaddress library.

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,35 +1,65 @@
-import pytest
+import ast
 
 
 def test_api_parse_succeeds(client):
-    # TODO: Finish this test. Send a request to the API and confirm that the
-    # data comes back in the appropriate format.
-
     # Arrange
     address_string = '123 main st chicago il'
+    prepared_string = address_string.replace(" ", "+")
+    url = "/api/parse/?address=" + prepared_string
 
     # Act
-    actual = None
+    response = client.get(url)
 
     # Assert
-    expected = Response({
-                'input_string': address_string,
-                'address_components': [],
-                'address_type': ""
-            })
-    assert expected == actual
+    assert response.status_code == 200
+    content = ast.literal_eval(response.content.decode('utf-8'))
+    assert content.get('input_string') == address_string
+    assert content.get('address_type') == "Street Address"
+    address_components = content.get('address_components')
+    assert address_components.get('AddressNumber') == "123"
+    assert address_components.get('StreetName') == "main"
+    assert address_components.get('StreetNamePostType') == "st"
+    assert address_components.get('PlaceName') == "chicago"
+    assert address_components.get('StateName') == "il"
 
 
-def test_api_parse_raises_error(client):
-    # TODO: Finish this test. The address_string below will raise a
-    # RepeatedLabelError, so ParseAddress.parse() will not be able to parse it.
-    
+def test_api_parse_raises_error_for_repeated_label(client):
     # Arrange
     address_string = '123 main st chicago il 123 main st'
+    prepared_string = address_string.replace(" ", "+")
+    url = "/api/parse/?address=" + prepared_string
 
     # Act
-    actual = None
+    response = client.get(url)
 
     # Assert
-    expected = None
-    assert actual == None
+    assert response.status_code == 400
+    content = ast.literal_eval(response.content.decode('utf-8'))
+    err = "Unable to tag this string because more than one area of the string has the"
+    assert err in content.get("detail")
+
+
+def test_api_parse_raises_error_if_blank_address(client):
+    # Arrange
+    url = "/api/parse/?address="
+
+    # Act
+    response = client.get(url)
+
+    # Assert
+    assert response.status_code == 400
+    content = ast.literal_eval(response.content.decode('utf-8'))
+    assert content.get("detail") == "Non-blank address query param must be provided."
+
+
+def test_api_parse_raises_error_if_no_address(client):
+    # Arrange
+    url = "/api/parse/"
+
+    # Act
+    response = client.get(url)
+
+    # Assert
+    assert response.status_code == 400
+    content = ast.literal_eval(response.content.decode('utf-8'))
+    assert content.get("detail") == "Non-blank address query param must be provided."


### PR DESCRIPTION
## Overview

This Pull Request recreates DataMade's "Parserator" Web Service functionality. A web form sends a GET request to a Python API, which then uses DataMade's "usaddress" to parse a url and return the parsed response, which the web form then uses to update its view and render the parsed address to the user.

Closes challenge: https://github.com/datamade/code-challenge/blob/master/README.md

### Demo

Valid Input: 400 Robert D. Ray Drive Des Moines IA 50309

![image](https://user-images.githubusercontent.com/17485463/186984074-b34a054c-7a01-4e8b-ace9-ea93a5ec0970.png)

Invalid Input: 400 Robert D. Ray Drive Des Moines IA 50309 400 Robert

![image](https://user-images.githubusercontent.com/17485463/186984142-1bceffd5-1ae0-4587-bf1e-fb7d2f617266.png)

### Notes

For the purposes of the challenge, in case of a parsing error I return the error's details from usaddress in the REST response and display that message to the user. It would likely be better to provide a less verbose error message to the user.

## Testing Instructions

After checking out this branch locally:

* Setup
  * Install Docker and Docker Compose (restart may be required)
  * Build the Docker containers with 'docker-compose build'
  * Run the App with 'docker-compose up' (if you're on Windows, you may need to fix line-endings with 'dos2unix docker-entrypoint.sh')
  * Verify the app is running at http://localhost:8000
* Test Case: Valid Input
  * Go to the app in your browser: http://localhost:8000
  * Test valid input by entering "400 Robert D. Ray Drive Des Moines IA 50309" and hitting "parse".
  * Verify the address type and address components show and appear correct.
* Test Case: Invalid Input
  * Go to the app in your browser: http://localhost:8000
  * Test invalid input by entering "400 Robert D. Ray Drive Des Moines IA 50309 400 Robert" and hitting "parse".
  * Verify a relevant error message displays and that the address type and components do not show.
* Additional Testing
  * If desired, test with more inputs.
  * Run unit tests and linter with 'docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app' (if you're on Windows, you may need to fix line-endings with 'dos2unix scripts/run-tests.sh')
