### PR TITLE
Submission to Implement Frontend for usaddress API call

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,5 +11,11 @@ module.exports = {
     "space-in-parens": ["error", "never"],
     "space-before-function-paren": ["error", "always"],
     "space-before-blocks": ["error", "always"]
+  },
+  "parserOptions": {
+    "ecmaVersion": "latest"
+  },
+  "env": {
+    "es6": true
   }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 #
 # Read more on Dockerfile best practices at the source:
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices
-RUN apt-get update && apt-get install -y --no-install-recommends postgresql-client nodejs
+RUN apt-get update && apt-get install -y --no-install-recommends postgresql-client nodejs npm
 
 # Inside the container, create an app directory and switch into it
 RUN mkdir /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2.4'
-
 services:
   app:
     image: parserator

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -1,27 +1,29 @@
+'use strict'
+
 // TODO: We'll want to change this url in production, obviously
-const url = "http://localhost:8000/api/parse";
-const submitButton = document.getElementById("submit");
+const url = "http://localhost:8000/api/parse"
+const submitButton = document.getElementById("submit")
 
 // We'll save the blank results html for use later
-let blankTable = document.getElementById("address-table").innerHTML;
+let blankTable = document.getElementById("address-table").innerHTML
 
-submitButton.onclick = async function(event) {
-  event.preventDefault();
+submitButton.onclick = async function (event) {
+  event.preventDefault()
   
-  let results = document.getElementById("address-results");
+  let results = document.getElementById("address-results")
 
   // We'll blank this out in case we get an error
   // So that we don't show old responses as if to new queries
-  results.style.display = "none";
+  results.style.display = "none"
   
-  let addressString = document.getElementById("address").value;
-  let queryTerms = new URLSearchParams({ address: addressString });
+  let addressString = document.getElementById("address").value
+  let queryTerms = new URLSearchParams({ address: addressString })
   try {
-    const response = await fetch(`${url}?${queryTerms}`);
+    const response = await fetch(`${url}?${queryTerms}`)
     console.log(response)
     if (!response.ok) {
       if (response.status == 400) {
-        alert(`${response.statusText}: Failed to parse this address`);
+        alert(`${response.statusText}: Failed to parse this address`)
       } else {
         // TODO: Handle other failures?
       }
@@ -29,26 +31,26 @@ submitButton.onclick = async function(event) {
       let responseData = await response.json()
 
       // Set the headline
-      document.getElementById("parse-type").textContent = responseData.address_type;
+      document.getElementById("parse-type").textContent = responseData.address_type
 
       // Build the table
-      let table = document.getElementById("address-table");
-      table.innerHTML = blankTable;
-      let addressParts = responseData.address_components;
+      let table = document.getElementById("address-table")
+      table.innerHTML = blankTable
+      let addressParts = responseData.address_components
       for (let index in addressParts) {
-        let field = addressParts[index][0];
-        let value = addressParts[index][1];
+        let field = addressParts[index][0]
+        let value = addressParts[index][1]
 
-        let nextRow = table.insertRow(-1);
-        let fieldData = nextRow.insertCell(0);
-        let valueData = nextRow.insertCell(1);
+        let nextRow = table.insertRow(-1)
+        let fieldData = nextRow.insertCell(0)
+        let valueData = nextRow.insertCell(1)
   
-        fieldData.appendChild(document.createTextNode(field));
-        valueData.appendChild(document.createTextNode(value));
+        fieldData.appendChild(document.createTextNode(field))
+        valueData.appendChild(document.createTextNode(value))
       }
-      results.style.display = "block";
+      results.style.display = "block"
     }
   } catch (error) {
-    console.error(`${error} in response to query at ${url}?{queryTerms}`);
+    console.error(`${error} in response to query at ${url}?{queryTerms}`)
   }
-};
+}

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -19,6 +19,35 @@ submitButton.onclick = async function(event) {
   try {
     const response = await fetch(`${url}?${queryTerms}`);
     console.log(response)
+    if (!response.ok) {
+      if (response.status == 400) {
+        alert(`${response.statusText}: Failed to parse this address`);
+      } else {
+        // TODO: Handle other failures?
+      }
+    } else {
+      let responseData = await response.json()
+
+      // Set the headline
+      document.getElementById("parse-type").textContent = responseData.address_type;
+
+      // Build the table
+      let table = document.getElementById("address-table");
+      table.innerHTML = blankTable;
+      let addressParts = responseData.address_components;
+      for (let index in addressParts) {
+        let field = addressParts[index][0];
+        let value = addressParts[index][1];
+
+        let nextRow = table.insertRow(-1);
+        let fieldData = nextRow.insertCell(0);
+        let valueData = nextRow.insertCell(1);
+  
+        fieldData.appendChild(document.createTextNode(field));
+        valueData.appendChild(document.createTextNode(value));
+      }
+      results.style.display = "block";
+    }
   } catch (error) {
     console.error(`${error} in response to query at ${url}?{queryTerms}`);
   }

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -1,2 +1,25 @@
-/* TODO: Flesh this out to connect the form to the API and render results
-   in the #address-results div. */
+// TODO: We'll want to change this url in production, obviously
+const url = "http://localhost:8000/api/parse";
+const submitButton = document.getElementById("submit");
+
+// We'll save the blank results html for use later
+let blankTable = document.getElementById("address-table").innerHTML;
+
+submitButton.onclick = async function(event) {
+  event.preventDefault();
+  
+  let results = document.getElementById("address-results");
+
+  // We'll blank this out in case we get an error
+  // So that we don't show old responses as if to new queries
+  results.style.display = "none";
+  
+  let addressString = document.getElementById("address").value;
+  let queryTerms = new URLSearchParams({ address: addressString });
+  try {
+    const response = await fetch(`${url}?${queryTerms}`);
+    console.log(response)
+  } catch (error) {
+    console.error(`${error} in response to query at ${url}?{queryTerms}`);
+  }
+};

--- a/parserator_web/templates/parserator_web/index.html
+++ b/parserator_web/templates/parserator_web/index.html
@@ -21,7 +21,7 @@
       <div id="address-results" style="display:none">
         <h4>Parsing results</h4>
         <p>Address type: <strong><span id="parse-type"></span></strong></p>
-        <table class="table table-bordered">
+        <table class="table table-bordered" id="address-table">
           <thead>
             <tr>
               <th>Address part</th>

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -23,9 +23,13 @@ class AddressParse(APIView):
             return Response({"input_string": input_string,
                              "address_components": address_components,
                              "address_type": address_type})
-        except usaddress.RepeatedLabelError:
+        except ParseError:
             return Response({"error": "This address failed to parse"}, status=400)
 
     def parse(self, address):
         # We'll let our library to the heavy lifting here
-        return usaddress.tag(address)
+        # And we'll re-throw the usaddress exception as a ParseError
+        try:
+            return usaddress.tag(address)
+        except usaddress.RepeatedLabelError:
+            raise ParseError

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -14,15 +14,15 @@ class AddressParse(APIView):
     renderer_classes = [JSONRenderer]
 
     def get(self, request):
-        # TODO: Flesh out this method to parse an address string using the
-        # parse() method and return the parsed components to the frontend.
-        return Response({})
+        input_string = request.GET.get("address")
+        try:
+            address_components, address_type = parse(input_string)
+            return Response({"input_string": input_string,
+                             "address_components": address_components,
+                             "address_type": address_type})
+        except usaddress.RepeatedLabelError:
+            return Response({})
 
     def parse(self, address):
-        try:
-            # We'll let our library to the heavy lifting here
-            address_components, address_type = usaddress.tag(address)
-        except RepeatedLabelError:
-            # TODO: propagate this error?
-            pass
-        return address_components, address_type
+        # We'll let our library to the heavy lifting here
+        return usaddress.tag(address)

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -16,12 +16,15 @@ class AddressParse(APIView):
     def get(self, request):
         input_string = request.GET.get("address")
         try:
-            address_components, address_type = parse(input_string)
+            components, address_type = self.parse(input_string)
+            address_components = []
+            for comp in components:
+                address_components.append((comp, components[comp]))
             return Response({"input_string": input_string,
                              "address_components": address_components,
                              "address_type": address_type})
         except usaddress.RepeatedLabelError:
-            return Response({})
+            return Response({"error": "This address failed to parse"}, status=400)
 
     def parse(self, address):
         # We'll let our library to the heavy lifting here

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -19,6 +19,10 @@ class AddressParse(APIView):
         return Response({})
 
     def parse(self, address):
-        # TODO: Implement this method to return the parsed components of a
-        # given address using usaddress: https://github.com/datamade/usaddress
+        try:
+            # We'll let our library to the heavy lifting here
+            address_components, address_type = usaddress.tag(address)
+        except RepeatedLabelError:
+            # TODO: propagate this error?
+            pass
         return address_components, address_type

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2.4'
-
 services:
   app:
     # Don't restart the service when the command exits

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2,14 +2,24 @@ import pytest
 
 
 def test_api_parse_succeeds(client):
-    # TODO: Finish this test. Send a request to the API and confirm that the
-    # data comes back in the appropriate format.
+    # We're going to test just the status code and json of the response
+    # Testing of e.g., templates or contexts should be done elsewhere
     address_string = '123 main st chicago il'
-    pytest.fail()
+    response = client.get("/api/parse", {"address": address_string}, follow=True)
+    assert response.json() == {"address_components": [["AddressNumber", "123"],
+                                                      ["StreetName", "main"],
+                                                      ["StreetNamePostType", "st"],
+                                                      ["PlaceName", "chicago"],
+                                                      ["StateName", "il"]],
+                               "address_type": "Street Address",
+                               "input_string": "123 main st chicago il"}
+    assert response.status_code == 200
 
 
 def test_api_parse_raises_error(client):
     # TODO: Finish this test. The address_string below will raise a
     # RepeatedLabelError, so ParseAddress.parse() will not be able to parse it.
     address_string = '123 main st chicago il 123 main st'
-    pytest.fail()
+    response = client.get("/api/parse", {"address": address_string}, follow=True)
+    assert response.json() == {"error": "This address failed to parse"}
+    assert response.status_code == 400

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,6 +1,3 @@
-import pytest
-
-
 def test_api_parse_succeeds(client):
     # We're going to test just the status code and json of the response
     # Testing of e.g., templates or contexts should be done elsewhere


### PR DESCRIPTION
## Overview

This pull links the form template front-end to the API for parsing addresses.

Also, closes #38.

### Demo

On success, a table is populated with the information:

![parserator-success](https://github.com/user-attachments/assets/5c274f8a-f3b8-45c3-8384-db4c930b3ebe)

On failure, an alert is generated and the table is cleared:

![parserator-failure](https://github.com/user-attachments/assets/93595fc8-aac8-4c24-b3f7-d457775613e9)

### Notes

Note that the url is currently hard-coded into `parserator_web/static/js/index.js` as `localhost:8000`.

Http responses other than 200 (success) and 400 (parse failure) are not handled.

No text processing was done on the field names of the addresses, so they are still in CamelCase, which isn't particularly user friendly for a front end.

## Testing Instructions
* docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app
* Successful case: `123 main st chicago il` returns status code 200 and json:
```
{"address_components": [["AddressNumber", "123"],
                        ["StreetName", "main"],
                        ["StreetNamePostType", "st"],
                        ["PlaceName", "chicago"],
                        ["StateName", "il"]],
 "address_type": "Street Address",
 "input_string": "123 main st chicago il"}
```
* Unsuccessful case `123 main st chicago il 123 main st` returns status code 400 and json:
```
{"error": "This address failed to parse"}
```
![tests](https://github.com/user-attachments/assets/c8b89fe3-9cc3-42ce-b220-04c863e785df)