### PR TITLE
Datamade Challenge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 #
 # Read more on Dockerfile best practices at the source:
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices
-RUN apt-get update && apt-get install -y --no-install-recommends postgresql-client nodejs
+RUN apt-get update && apt-get install -y --no-install-recommends postgresql-client nodejs npm
 
 # Inside the container, create an app directory and switch into it
 RUN mkdir /app

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -1,2 +1,48 @@
 /* TODO: Flesh this out to connect the form to the API and render results
    in the #address-results div. */
+// URL for the local API endpoint
+const url = "http://localhost:8000/api/parse"; // TODO: Change this URL in production
+
+// Get the submit button element by its ID
+const submitButton = document.getElementById("submit");
+
+// Save the blank HTML for the results table to reset it later
+let blankTable = document.getElementById("address-table").innerHTML;
+
+submitButton.onclick = async function(event) {
+    event.preventDefault(); // Prevent the default form submission behavior
+
+    // Get the results div element by its ID
+    let results = document.getElementById("address-results");
+
+    // Hide the results div and reset its content in case of an error
+    results.style.display = "none";
+
+    // Get the value from the address input field
+    let addressString = document.getElementById("address").value;
+
+    // Create URL query parameters using the address input value
+    let queryTerms = new URLSearchParams({ address: addressString });
+
+    try {
+        // Fetch the parsed address from the API endpoint with the query parameters
+        const response = await fetch(`${url}?${queryTerms}`);
+
+        // Check if the response is ok (status code 200-299)
+        if (!response.ok) {
+            throw new Error(`HTTP error! Status: ${response.status}`);
+        }
+
+        // Parse the JSON response
+        const data = await response.json();
+
+        // Display the parsed address components in the results div
+        results.innerText = `Parsed Address Components: ${JSON.stringify(data.address_components)}`;
+        results.style.display = "block";
+    } catch (error) {
+        // Display the error message in the results div
+        results.innerText = `Error: ${error.message}`;
+        results.style.display = "block";
+        console.error(`${error} in response to query at ${url}?${queryTerms}`);
+    }
+};

--- a/parserator_web/templates/parserator_web/index.html
+++ b/parserator_web/templates/parserator_web/index.html
@@ -22,6 +22,7 @@
         <h4>Parsing results</h4>
         <p>Address type: <strong><span id="parse-type"></span></strong></p>
         <table class="table table-bordered">
+        <table class="table table-bordered" id="address-table">
           <thead>
             <tr>
               <th>Address part</th>


### PR DESCRIPTION
Demo
![image](https://github.com/user-attachments/assets/0adddf2e-f6dd-4bd5-8611-01231349ee88)



Parsed Address Components:
Notes

    The API endpoint URL is currently set to http://localhost:8000/api/parse and should be updated for production.
    Ensure Docker is running before starting the application.

Testing Instructions

    Check out this branch.
    Ensure Docker and Docker Compose are installed.
    Build and run the application:

    bash

docker-compose build
docker-compose up

Navigate to http://localhost:8000.
Enter an address in the form and submit.
Verify that the parsed address components are displayed correctly.